### PR TITLE
sorted, integer ports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,6 @@ Description: R interface for the 'netstat' command line utility used to retrieve
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Imports: utils
 Language: en-US

--- a/R/ports_in_use.R
+++ b/R/ports_in_use.R
@@ -56,7 +56,9 @@ ports_in_use <- function() {
 
          }
 
-         )
+         ) -> out
+
+  sort(as.integer(out[grepl("^[[:digit:]]+$", out)]))
 
 }
 


### PR DESCRIPTION
current implementation has non-numeric entries (e.g.`*` as noted in `ports_in_use.R` ) and doesn't return sorted results. This PR changes the behaviour to only return integer ports and does so sorted so it's easier to eyeball a free port in a favourite range area.